### PR TITLE
Require bundler > 2.3

### DIFF
--- a/cocoapods-fix-react-native-csb.gemspec
+++ b/cocoapods-fix-react-native-csb.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Effectively resolves CVE-2021-43809 and CVE-2016-7954, although neither were really an issue anyway.